### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: "DevContainer Features - Test"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/dev-container-features/security/code-scanning/9](https://github.com/gvatsal60/dev-container-features/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with repository contents (e.g., checking out code), the `contents: read` permission is sufficient. This block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions per job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
