### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/dev-container-features/security/code-scanning/1](https://github.com/gvatsal60/dev-container-features/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs linting tasks, it requires minimal permissions. The `contents: read` permission is sufficient for accessing the repository files for linting. This change ensures that the workflow does not inherit unnecessary permissions, reducing the risk of unintended actions.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs within the workflow. No additional dependencies or changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
