### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,4 +1,6 @@
 name: "PR - Test Updated Features"
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/dev-container-features/security/code-scanning/4](https://github.com/gvatsal60/dev-container-features/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears that the jobs primarily involve checking out code and running tests, so the `contents: read` permission should suffice. If any job requires additional permissions (e.g., `pull-requests: write`), they can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
