### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-metadata-files.yaml
+++ b/.github/workflows/validate-metadata-files.yaml
@@ -1,4 +1,6 @@
 name: "Validate devcontainer-feature.json files"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/dev-container-features/security/code-scanning/5](https://github.com/gvatsal60/dev-container-features/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only validates files and does not require write access, the permissions can be set to `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimal permissions necessary to complete the task securely.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
