### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,7 @@
 name: "DevContainer Features - Release"
+permissions:
+  contents: read
+  packages: write
 on:
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: "DevContainer Features - Release"
 permissions:
-  contents: read
+  contents: write
   packages: write
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/dev-container-features/security/code-scanning/2](https://github.com/gvatsal60/dev-container-features/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality:
- The `run-tests` job does not seem to require any permissions, as it uses another workflow (`test.yaml`) and inherits secrets.
- The `deploy` job uses the `GITHUB_TOKEN` to publish features, so it likely requires `contents: read` and possibly `packages: write` or similar permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient since the permissions are minimal and consistent across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
